### PR TITLE
fix: status monitor to regenerated after disconnect

### DIFF
--- a/OpenttdDiscord.Base/OpenttdDiscord.Base.csproj
+++ b/OpenttdDiscord.Base/OpenttdDiscord.Base.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="LanguageExt.Core" Version="4.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-	<PackageReference Include="Shoter.OpenTTD.AdminPort" Version="1.0.0-run-64" />
+	<PackageReference Include="Shoter.OpenTTD.AdminPort" Version="1.0.0-run-65" />
   </ItemGroup>
 
 </Project>

--- a/OpenttdDiscord.Infrastructure/Ottd/Actors/GuildServerActor.cs
+++ b/OpenttdDiscord.Infrastructure/Ottd/Actors/GuildServerActor.cs
@@ -168,11 +168,11 @@ namespace OpenttdDiscord.Infrastructure.Ottd.Actors
 
         private async Task UpdateStatusMonitor(UpdateStatusMonitor usm)
         {
-            await this.RemoveStatusMonitor(new(usm.UpdatedMonitor.ServerId, usm.UpdatedMonitor.GuildId, usm.UpdatedMonitor.ChannelId));
             var self = Self;
             var monitorResult = await this.updateStatusMonitorUseCase.Execute(User.Master, usm.UpdatedMonitor);
-            monitorResult.Map(monitor =>
+            await monitorResult.MapAsync(async monitor =>
             {
+                await this.RemoveStatusMonitor(new(usm.UpdatedMonitor.ServerId, usm.UpdatedMonitor.GuildId, usm.UpdatedMonitor.ChannelId));
                 self.Tell(new RegisterStatusMonitor(monitor));
                 return Unit.Default;
             });

--- a/OpenttdDiscord.Infrastructure/Statuses/Actors/StatusMonitorActor.cs
+++ b/OpenttdDiscord.Infrastructure/Statuses/Actors/StatusMonitorActor.cs
@@ -42,6 +42,8 @@ namespace OpenttdDiscord.Infrastructure.Statuses.Actors
             Ready();
             Timers.StartPeriodicTimer("regenerate", new RegenerateStatusMonitor(), TimeSpan.FromMinutes(1));
             Self.Tell(new RegenerateStatusMonitor());
+
+            logger.LogDebug($"MonitorActor created for {statusMonitor.ServerId}-{statusMonitor.ChannelId}");
         }
 
         private void Ready()
@@ -127,10 +129,10 @@ namespace OpenttdDiscord.Infrastructure.Statuses.Actors
             await message.Value.DeleteAsync();
         }
 
-        protected override void PostStop()
+        public override void AroundPreRestart(Exception cause, object message)
         {
-            base.PostStop();
-            logger.LogError($"{statusMonitor.ServerId}-{statusMonitor.ChannelId} is being stopped");
+            logger.LogError($"{statusMonitor.ServerId}-{statusMonitor.ChannelId} is being restarted after {message} because:\n {cause}");
+            base.AroundPreRestart(cause, message);
         }
     }
 }

--- a/OpenttdDiscord.Infrastructure/Statuses/Actors/StatusMonitorActor.cs
+++ b/OpenttdDiscord.Infrastructure/Statuses/Actors/StatusMonitorActor.cs
@@ -59,33 +59,47 @@ namespace OpenttdDiscord.Infrastructure.Statuses.Actors
 
         private async Task RegenerateStatusMonitor(RegenerateStatusMonitor _)
         {
-            ServerStatus serverStatus = await client.QueryServerStatus();
-            AdminServerInfo info = serverStatus.AdminServerInfo;
-
-            Embed embed = EmbedBuilder.CreateServerStatusEmbed(client, serverStatus, info, ottdServer.Name);
+            Embed embed = await CreateEmbed();
             Optional<RestUserMessage> message = await GetMessage();
 
             if (!message.IsSpecified)
             {
-                var channel = (IMessageChannel)await discord.GetChannelAsync(statusMonitor.ChannelId);
-                var newMessage = await channel.SendMessageAsync(embed: embed);
-                Context.Parent.Tell(new UpdateStatusMonitor(this.statusMonitor with
-                {
-                    MessageId = newMessage.Id
-                }));
-
-                logger.LogDebug("No message detected. Created new - recreating status monitor for {0} at {1}", ottdServer.Name, statusMonitor.ChannelId);
+                await RegenerateMessage(embed);
+                return;
             }
-            else
+
+            await UpdateMessage(embed, message);
+        }
+
+        private async Task<Embed> CreateEmbed()
+        {
+            ServerStatus serverStatus = await client.QueryServerStatus();
+            AdminServerInfo info = serverStatus.AdminServerInfo;
+
+            return EmbedBuilder.CreateServerStatusEmbed(client, serverStatus, info, ottdServer.Name);
+        }
+
+        private async Task UpdateMessage(Embed embed, Optional<RestUserMessage> message)
+        {
+            await message.Value.ModifyAsync(x =>
             {
-                await message.Value.ModifyAsync(x =>
-                {
-                    x.Content = null;
-                    x.Embed = embed;
-                });
+                x.Content = null;
+                x.Embed = embed;
+            });
 
-                logger.LogDebug("Regenerated status monitor for {0} at {1}", ottdServer.Name, statusMonitor.ChannelId);
-            }
+            logger.LogDebug("Regenerated status monitor for {0} at {1}", ottdServer.Name, statusMonitor.ChannelId);
+        }
+
+        private async Task RegenerateMessage(Embed embed)
+        {
+            var channel = (IMessageChannel)await discord.GetChannelAsync(statusMonitor.ChannelId);
+            var newMessage = await channel.SendMessageAsync(embed: embed);
+            Context.Parent.Tell(new UpdateStatusMonitor(this.statusMonitor with
+            {
+                MessageId = newMessage.Id
+            }));
+
+            logger.LogDebug("No message detected. Created new - recreating status monitor for {0} at {1}", ottdServer.Name, statusMonitor.ChannelId);
         }
 
         private async Task<Optional<RestUserMessage>> GetMessage()
@@ -111,6 +125,12 @@ namespace OpenttdDiscord.Infrastructure.Statuses.Actors
             }
 
             await message.Value.DeleteAsync();
+        }
+
+        protected override void PostStop()
+        {
+            base.PostStop();
+            logger.LogError($"{statusMonitor.ServerId}-{statusMonitor.ChannelId} is being stopped");
         }
     }
 }


### PR DESCRIPTION
closes #25 

Issue was simple - status monitor actor was waiting for akka message reply that would never happen. Modified AdminPort to handle that with timeout of 2 seconds.