### PR TITLE
test: add new test

### DIFF
--- a/OpenttdDiscord.Infrastructure.Tests/EventLogs/Actors/EventStorageActorShould.cs
+++ b/OpenttdDiscord.Infrastructure.Tests/EventLogs/Actors/EventStorageActorShould.cs
@@ -1,0 +1,52 @@
+using Akka.Actor;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using OpenTTDAdminPort;
+using OpenTTDAdminPort.Game;
+using OpenttdDiscord.Domain.AutoReplies;
+using OpenttdDiscord.Domain.Servers;
+using OpenttdDiscord.Infrastructure.EventLogs.Actors;
+using OpenttdDiscord.Infrastructure.EventLogs.Messages;
+using Xunit.Abstractions;
+
+namespace OpenttdDiscord.Infrastructure.Tests.EventLogs.Actors
+{
+    public class EventStorageActorShould : BaseActorTestKit
+    {
+        private readonly IFixture fix = new Fixture();
+        private readonly IAdminPortClient adminPortClientSut = Substitute.For<IAdminPortClient>();
+        private readonly OttdServer server;
+
+        public EventStorageActorShould(ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+            server = fix.Create<OttdServer>();
+        }
+
+        public async Task NotHaveMoreMessagesThanLimit()
+        {
+            var actor = CreateSut();
+            for (int i = 0; i < 650; ++i)
+            {
+                actor.Tell(i.ToString());
+            }
+
+            await Task.Delay(0.5.Seconds());
+
+            var eventLog = await actor.Ask<RetrievedEventLog>(new RetrieveEventLog(server.Id, server.GuildId));
+            eventLog.Messages.Count.Should()
+                .Be(EventStorageActor.ChatMessageMaxCount);
+        }
+
+        private IActorRef CreateSut()
+        {
+            var sut = ActorOf(
+                EventStorageActor.Create(
+                    Sp,
+                    server,
+                    adminPortClientSut
+                ));
+            return sut;
+        }
+    }
+}

--- a/OpenttdDiscord.Infrastructure.Tests/EventLogs/Actors/EventStorageActorShould.cs
+++ b/OpenttdDiscord.Infrastructure.Tests/EventLogs/Actors/EventStorageActorShould.cs
@@ -13,7 +13,6 @@ namespace OpenttdDiscord.Infrastructure.Tests.EventLogs.Actors
 {
     public class EventStorageActorShould : BaseActorTestKit
     {
-        private readonly IFixture fix = new Fixture();
         private readonly IAdminPortClient adminPortClientSut = Substitute.For<IAdminPortClient>();
         private readonly OttdServer server;
 
@@ -23,6 +22,7 @@ namespace OpenttdDiscord.Infrastructure.Tests.EventLogs.Actors
             server = fix.Create<OttdServer>();
         }
 
+        [Fact]
         public async Task NotHaveMoreMessagesThanLimit()
         {
             var actor = CreateSut();

--- a/OpenttdDiscord.Infrastructure/EventLogs/Actors/EventStorageActor.cs
+++ b/OpenttdDiscord.Infrastructure/EventLogs/Actors/EventStorageActor.cs
@@ -143,7 +143,6 @@ namespace OpenttdDiscord.Infrastructure.EventLogs.Actors
             if (!Directory.Exists(directoryPath))
             {
                 Directory.CreateDirectory(directoryPath);
-                Console.WriteLine("Directories created.");
             }
 
             await File.WriteAllTextAsync(filePath, sb.ToString());

--- a/OpenttdDiscord.Infrastructure/EventLogs/Actors/EventStorageActor.cs
+++ b/OpenttdDiscord.Infrastructure/EventLogs/Actors/EventStorageActor.cs
@@ -18,7 +18,7 @@ namespace OpenttdDiscord.Infrastructure.EventLogs.Actors
     internal class EventStorageActor : ReceiveActorBase, IWithTimers
     {
         // TODO: Make it configurable through appsettings or something or whatever
-        private const int ChatMessageMaxCount = 600;
+        public const int ChatMessageMaxCount = 600;
 
         private readonly OttdServer ottdServer;
 


### PR DESCRIPTION
This branch was intended to fix a bug with event storing actor but in reality there was no bug. 

So i created unit test for it and just... deleted 1 old debug console writeline.

Still I need to look for reason why this bot is consuming more and more disk space over time. In 6-12 months of non-stop running it is usually very heavt on disk space. Maybe docker logs?

